### PR TITLE
Replace app name in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ A Qt/KDE implementation can be found in [xdg-desktop-portal-kde](https://cgit.kd
 To use this test, use the build script in flatpak-build/ to produce a flatpak of portal-test, then install it with
 
     flatpak remote-add --user --no-gpg-verify portal-test-kde file:///path/to/repo
-    flatpak install --user portal-test-kde org.kde.PortalTest
+    flatpak install --user portal-test-kde org.kde.portal-test-kde
 
 and run it with
 
-    flatpak run org.kde.PortalTest
+    flatpak run org.kde.portal-test-kde
 
 The test expects the xdg-desktop-portal service (and a backend, such as xdg-desktop-portal-kde) to be available on the session bus.


### PR DESCRIPTION
It seems the app was renamed "org.kde.portal-test-kde" but the instructions in the README not.